### PR TITLE
Migrate to CoverDeviceClass

### DIFF
--- a/custom_components/slide/cover.py
+++ b/custom_components/slide/cover.py
@@ -6,13 +6,13 @@ import voluptuous as vol
 from goslideapi import GoSlideLocal
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    DEVICE_CLASS_CURTAIN,
     PLATFORM_SCHEMA,
     STATE_CLOSED,
     STATE_CLOSING,
     STATE_OPEN,
     STATE_OPENING,
     CoverEntity,
+    CoverDeviceClass
 )
 from homeassistant.const import ATTR_ID, CONF_HOST, CONF_PASSWORD
 from homeassistant.helpers import config_validation as cv, entity_platform
@@ -149,7 +149,7 @@ class SlideCoverCloud(CoverEntity):
     @property
     def device_class(self):
         """Return the device class of the cover."""
-        return DEVICE_CLASS_CURTAIN
+        return CoverDeviceClass.CURTAIN
 
     @property
     def current_cover_position(self):
@@ -266,7 +266,7 @@ class SlideCoverLocal(CoverEntity):
     @property
     def device_class(self):
         """Return the device class of the cover."""
-        return DEVICE_CLASS_CURTAIN
+        return CoverDeviceClass.CURTAIN
 
     @property
     def current_cover_position(self):


### PR DESCRIPTION
Fixes a warning about usage of the old DEVICE_CLASS_CURTAIN constant