### PR TITLE
Update API to v0.6.7, fix HA 2024.1 compatibility

### DIFF
--- a/custom_components/slide/cover.py
+++ b/custom_components/slide/cover.py
@@ -6,13 +6,13 @@ import voluptuous as vol
 from goslideapi import GoSlideLocal
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    DEVICE_CLASS_CURTAIN,
     PLATFORM_SCHEMA,
     STATE_CLOSED,
     STATE_CLOSING,
     STATE_OPEN,
     STATE_OPENING,
     CoverEntity,
+    CoverDeviceClass,
 )
 from homeassistant.const import ATTR_ID, CONF_HOST, CONF_PASSWORD
 from homeassistant.helpers import config_validation as cv, entity_platform
@@ -57,7 +57,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         await hass.data[DOMAIN][API_LOCAL].slide_add(
             config.get(CONF_HOST),
             config.get(CONF_PASSWORD),
-            config.get(CONF_API_VERSION),
         )
 
         slide = await hass.data[DOMAIN][API_LOCAL].slide_info(config.get(CONF_HOST))
@@ -149,7 +148,7 @@ class SlideCoverCloud(CoverEntity):
     @property
     def device_class(self):
         """Return the device class of the cover."""
-        return DEVICE_CLASS_CURTAIN
+        return CoverDeviceClass.CURTAIN
 
     @property
     def current_cover_position(self):
@@ -266,7 +265,7 @@ class SlideCoverLocal(CoverEntity):
     @property
     def device_class(self):
         """Return the device class of the cover."""
-        return DEVICE_CLASS_CURTAIN
+        return CoverDeviceClass.CURTAIN
 
     @property
     def current_cover_position(self):

--- a/custom_components/slide/manifest.json
+++ b/custom_components/slide/manifest.json
@@ -3,6 +3,6 @@
   "name": "Slide",
   "version": "1.0",
   "documentation": "https://www.home-assistant.io/integrations/slide",
-  "requirements": ["goslide-api==0.6.6"],
+  "requirements": ["goslide-api==0.6.7"],
   "codeowners": ["@ualex73"]
 }


### PR DESCRIPTION
- Replace deprecated constants to fix warnings in HA 2024.1
- Update API version to 0.6.7

**Fixes:**
- Fixes ualex73/slide#12
- Fixes ualex73/slide#10
- Fixes ualex73/slide#9
- Fixes ualex73/slide#8